### PR TITLE
Update M5Tough.h

### DIFF
--- a/src/M5Tough.h
+++ b/src/M5Tough.h
@@ -131,7 +131,7 @@
     #define m5 M5
     #define lcd Lcd
   #else
-    #error “This library only supports boards with ESP32 processor.”
+    #error "This library only supports boards with ESP32 processor."
   #endif
 #endif
 


### PR DESCRIPTION
M5Tough.h:134:12: error: extended character “ is not valid